### PR TITLE
Fix Django 3 support.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-tox>=2.3.1
-Django>=1.8
-Pillow>=3.3.0
+tox>=3.14.5
+Django>=3.0.3
+Pillow>=7.0.0
 tox-pyenv>=1.1.0
 tox-travis>=0.12
 pluggy>=0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cloudinary>=1.4.0
-python-magic>=0.4.12
-requests>=2.10.0
+cloudinary>=1.20.0
+python-magic>=0.4.15
+requests>=2.23.0

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,11 @@ setup(
         'cloudinary_storage.management.commands'],
     include_package_data=True,
     install_requires=[
-        'requests>=2.10.0',
-        'cloudinary>=1.4.0'
+        'requests>=2.23.0',
+        'cloudinary>=1.20.0'
     ],
     extras_require={
-        'video': ['python-magic>=0.4.12']
+        'video': ['python-magic>=0.4.15']
     },
     classifiers=[
         'Environment :: Web Environment',

--- a/tests/tests/test_commands.py
+++ b/tests/tests/test_commands.py
@@ -180,17 +180,18 @@ class CollectStaticCommandWithHashedStorageTests(SimpleTestCase):
         post_process_counter = 1 + 1 * get_postprocess_counter_of_adjustable_file()
         self.assertIn('2 static files copied, {} post-processed.'.format(post_process_counter), output)
 
-    # TODO: Make this test work in Django >= 2
-    # def test_command_saves_manifest_file(self, save_mock):
-    #     name = get_random_name()
-    #     StaticHashedCloudinaryStorage.manifest_name = name
-    #     execute_command('collectstatic', '--noinput')
-    #     try:
-    #         manifest_path = os.path.join(app_settings.STATICFILES_MANIFEST_ROOT, name)
-    #         self.assertTrue(os.path.exists(manifest_path))
-    #         os.remove(manifest_path)
-    #     finally:
-    #         StaticHashedCloudinaryStorage.manifest_name = 'staticfiles.json'
+
+class CollectStaticCommandWithHashedStorageWithoutMockTests(SimpleTestCase):
+    def test_command_saves_manifest_file(self):
+        name = get_random_name()
+        StaticHashedCloudinaryStorage.manifest_name = name
+        execute_command('collectstatic', '--noinput')
+        try:
+            manifest_path = os.path.join(app_settings.STATICFILES_MANIFEST_ROOT, name)
+            self.assertTrue(os.path.exists(manifest_path))
+            os.remove(manifest_path)
+        finally:
+            StaticHashedCloudinaryStorage.manifest_name = 'staticfiles.json'
 
 
 @override_settings(STATICFILES_STORAGE='cloudinary_storage.storage.StaticHashedCloudinaryStorage')

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = clean,{py35,py36,py37}-dj111,py37-dj228,py38-dj30,stats
+envlist = clean,{py35,py36,py37}-dj1,py37-dj2,py38-dj3,stats
 
 [testenv]
 deps =
     Pillow>=3.3.0
-    python-magic>=0.4.12
+    python-magic>=0.4.15
     coverage
-    dj111: Django>=1.11,<1.12
-    dj228: Django>=2.2.8,<2.2.9
-    dj30: Django>=3.0,<3.0.2
+    dj1: Django>=1.11,<1.12
+    dj2: Django>=2.2,<2.3
+    dj3: Django>=3.0,<3.1
 setenv =
     CLOUDINARY_CLOUD_NAME = {env:CLOUDINARY_CLOUD_NAME}
     CLOUDINARY_API_KEY = {env:CLOUDINARY_API_KEY}


### PR DESCRIPTION
- Update dependencies.
- Remove mock for `test_command_saves_manifest_file`. The function is OK, but mock showing a strange behave.

```TypeError: Object of type MagicMock is not JSON serializable```
![Mock behave](https://camo.githubusercontent.com/84871b68f9e1ba523f345edabae59c9749d0dcc3/68747470733a2f2f617773312e646973636f757273652d63646e2e636f6d2f7374616e6461726431302f75706c6f6164732f707974686f6e2f6f726967696e616c2f31582f373532643264333930363566393938363432396266323431663538643161626165666130373437382e706e67 "Mock behave")